### PR TITLE
feat: read compile diagnostics from project path

### DIFF
--- a/server/src/mcp/tools/diagnostics.rs
+++ b/server/src/mcp/tools/diagnostics.rs
@@ -129,7 +129,7 @@ impl McpService {
             .take(max_items as usize)
             .collect();
 
-        let truncated = filtered_diagnostics.len() < total_before;
+        let truncated = compile_diagnostics.truncated || filtered_diagnostics.len() < total_before;
 
         // Recalculate summary for filtered results
         let summary = self.calculate_summary(&filtered_diagnostics);


### PR DESCRIPTION
## Summary
- track Unity project path in `McpService`
- read compile diagnostics from project root with optional `UNITY_MCP_DIAG_PATH`
- update health/status/tests to use new path logic and avoid unstable `let` chains
- preserve `truncated` flag from compile diagnostics when filtering

## Testing
- `cd server && cargo fmt --all`
- `cd server && cargo clippy --all-targets -- -D warnings` *(fails: `let` expressions in tests)*
- `cd server && cargo test --quiet` *(fails: `let` expressions in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b41536fa188329872a7a65b2c0f438