### PR TITLE
fix: handle project settings error and restore in tests

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -750,6 +750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +813,7 @@ dependencies = [
  "regex",
  "rmcp",
  "schemars",
+ "scopeguard",
  "serde",
  "serde_json",
  "tempfile",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,4 +33,5 @@ transport-ipc = []
 tokio-stream = "0.1.17"
 tempfile = "3.14.0"
 regex = "1.10.6"
+scopeguard = "1.1.0"
 

--- a/server/src/mcp/tools/project_settings.rs
+++ b/server/src/mcp/tools/project_settings.rs
@@ -28,7 +28,7 @@ impl McpService {
             McpError::internal_error(format!("Project settings get IPC error: {}", e), None)
         })?;
 
-        let settings = match response.payload {
+        let resp = match response.payload {
             Some(crate::generated::mcp::unity::v1::ipc_response::Payload::GetProjectSettings(
                 r,
             )) => r,
@@ -40,8 +40,15 @@ impl McpService {
             }
         };
 
+        if !resp.success {
+            return Err(McpError::internal_error(
+                format!("Project settings get failed: {}", resp.error_message),
+                None,
+            ));
+        }
+
         let output = GetProjectSettingsOutput {
-            settings: settings.settings,
+            settings: resp.settings,
         };
         let content = serde_json::to_string(&output)
             .map_err(|e| McpError::internal_error(format!("Serialization error: {}", e), None))?;

--- a/server/tests/project_settings_integration.rs
+++ b/server/tests/project_settings_integration.rs
@@ -1,3 +1,4 @@
+use scopeguard::guard;
 use server::generated::mcp::unity::v1::{
     GetProjectSettingsRequest, IpcRequest, SetProjectSettingsRequest, ipc_request, ipc_response,
 };
@@ -48,6 +49,24 @@ async fn test_project_settings_roundtrip() {
         .get("companyName")
         .cloned()
         .unwrap_or_default();
+
+    // Ensure project setting is restored even if test panics
+    let restore_client = client.clone();
+    let _restore = guard(original.clone(), move |orig| {
+        let mut restore = HashMap::new();
+        restore.insert("companyName".to_string(), orig);
+        let set_req = SetProjectSettingsRequest { settings: restore };
+        let ipc_req = IpcRequest {
+            payload: Some(ipc_request::Payload::SetProjectSettings(set_req)),
+        };
+        tokio::spawn(async move {
+            let _ = timeout(
+                Duration::from_secs(5),
+                restore_client.request(ipc_req, Duration::from_secs(5)),
+            )
+            .await;
+        });
+    });
 
     // Set new companyName
     let mut map = HashMap::new();
@@ -111,17 +130,4 @@ async fn test_project_settings_roundtrip() {
         .cloned()
         .unwrap_or_default();
     assert_eq!(updated, "TestCo");
-
-    // Restore original value
-    let mut restore = HashMap::new();
-    restore.insert("companyName".to_string(), original);
-    let set_req = SetProjectSettingsRequest { settings: restore };
-    let ipc_req = IpcRequest {
-        payload: Some(ipc_request::Payload::SetProjectSettings(set_req)),
-    };
-    let _ = timeout(
-        Duration::from_secs(5),
-        client.request(ipc_req, Duration::from_secs(5)),
-    )
-    .await;
 }


### PR DESCRIPTION
## Summary
- propagate GetProjectSettings failures to callers
- safeguard project setting restoration in integration test
- add scopeguard dev-dependency

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` *(fails: this creates an owned instance just for comparison)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6531fa6ec83299a464a9fedd2c28c