### PR TITLE
fix: reset build settings when variants disabled

### DIFF
--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/BuildHandler.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/BuildHandler.cs
@@ -88,8 +88,13 @@ namespace Mcp.Unity.V1.Ipc
                 // TODO(UNITY_API): touches PlayerSettings/EditorUserBuildSettings — must run on main via EditorDispatcher
                 if (r.Variants?.Il2Cpp == true)
                     PlayerSettings.SetScriptingBackend(group, ScriptingImplementation.IL2CPP);
+                else
+                    PlayerSettings.SetScriptingBackend(group, ScriptingImplementation.Mono2x);
+
                 if (r.Variants?.StripSymbols == true)
                     EditorUserBuildSettings.stripEngineCode = true;
+                else
+                    EditorUserBuildSettings.stripEngineCode = false;
 
                 // 5. Build options setup
                 var buildOptions = BuildOptions.None;


### PR DESCRIPTION
## Summary
- explicitly reset scripting backend to Mono when Il2Cpp variant is disabled
- disable engine code stripping when StripSymbols variant is false

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b670b142688329931370a17cd40607