### PR TITLE
fix: handle prefab save failure

### DIFF
--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/PrefabHandler.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/PrefabHandler.cs
@@ -36,7 +36,9 @@ namespace Mcp.Unity.V1.Ipc
                 return new Pb.PrefabResponse { StatusCode = 5, Message = "game object not found" };
             try
             {
-                PrefabUtility.SaveAsPrefabAsset(go, r.PrefabPath);
+                var prefab = PrefabUtility.SaveAsPrefabAsset(go, r.PrefabPath);
+                if (prefab == null)
+                    return new Pb.PrefabResponse { StatusCode = 13, Message = "failed to save prefab" };
                 string guid = AssetDatabase.AssetPathToGUID(r.PrefabPath);
                 return new Pb.PrefabResponse
                 {
@@ -59,7 +61,9 @@ namespace Mcp.Unity.V1.Ipc
                 return new Pb.PrefabResponse { StatusCode = 5, Message = "game object not found" };
             try
             {
-                PrefabUtility.SaveAsPrefabAsset(go, r.PrefabPath);
+                var prefab = PrefabUtility.SaveAsPrefabAsset(go, r.PrefabPath);
+                if (prefab == null)
+                    return new Pb.PrefabResponse { StatusCode = 13, Message = "failed to save prefab" };
                 return new Pb.PrefabResponse
                 {
                     StatusCode = 0,


### PR DESCRIPTION
## Summary
- return error when PrefabUtility.SaveAsPrefabAsset fails

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `dotnet format unity-mcp.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b6709357c08329ad1f3bb3ee5efd55