### PR TITLE
fix: Unity標準コンポーネントの型解決を改善

### DIFF
--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ComponentsHandler.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ComponentsHandler.cs
@@ -14,12 +14,25 @@ namespace Mcp.Unity.V1.Ipc
                 return type;
             }
 
-            if (name.Contains("."))
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
             {
-                return Type.GetType($"{name}, UnityEngine");
+                type = asm.GetType(name);
+                if (type != null)
+                {
+                    return type;
+                }
+
+                if (!name.Contains("."))
+                {
+                    type = asm.GetType($"UnityEngine.{name}");
+                    if (type != null)
+                    {
+                        return type;
+                    }
+                }
             }
 
-            return Type.GetType($"UnityEngine.{name}, UnityEngine");
+            return null;
         }
 
         public static Pb.ComponentResponse Handle(Pb.ComponentRequest req, Bridge.Editor.Ipc.FeatureGuard features)


### PR DESCRIPTION
## Summary
- `FindType` がロード済みアセンブリを走査し、名前にドットがない場合のみ `UnityEngine.` を補うように変更

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --test components_integration`


------
https://chatgpt.com/codex/tasks/task_e_68b676b0d8608329b253d231de475fde