### PR TITLE
fix: search loaded assemblies for Unity component types

### DIFF
--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ComponentsHandler.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ComponentsHandler.cs
@@ -14,12 +14,25 @@ namespace Mcp.Unity.V1.Ipc
                 return type;
             }
 
-            if (name.Contains("."))
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
             {
-                return Type.GetType($"{name}, UnityEngine");
+                type = asm.GetType(name);
+                if (type != null)
+                {
+                    return type;
+                }
+
+                if (!name.Contains('.'))
+                {
+                    type = asm.GetType($"UnityEngine.{name}");
+                    if (type != null)
+                    {
+                        return type;
+                    }
+                }
             }
 
-            return Type.GetType($"UnityEngine.{name}, UnityEngine");
+            return null;
         }
 
         public static Pb.ComponentResponse Handle(Pb.ComponentRequest req, Bridge.Editor.Ipc.FeatureGuard features)


### PR DESCRIPTION
## Summary
- resolve component types by scanning all loaded assemblies

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --test components_integration`


------
https://chatgpt.com/codex/tasks/task_e_68b676c7c070832990d7729973443dc2