### PR TITLE
fix: resolve UnityEditor window types for FocusWindow RPC

### DIFF
--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/EditorIpcServer.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/EditorIpcServer.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using Google.Protobuf;
@@ -470,7 +471,10 @@ namespace Mcp.Unity.V1.Ipc
             var focusResponse = await EditorDispatcher.RunOnMainAsync(() =>
             {
                 MainThreadGuard.AssertMainThread();
-                var type = System.Type.GetType(request.WindowType);
+                var type = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .Select(asm => asm.GetType(request.WindowType))
+                    .FirstOrDefault(t => t != null);
                 bool ok = false;
                 if (type != null)
                 {


### PR DESCRIPTION
## Summary
- search all loaded assemblies to resolve requested window type in FocusWindow RPC

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b67835b90c8329a15d472e5ef2d565