### PR TITLE
test: clean up Unity meta files in scene test

### DIFF
--- a/server/tests/scene_integration.rs
+++ b/server/tests/scene_integration.rs
@@ -64,9 +64,9 @@ async fn test_scene_operations_end_to_end() {
         assert!(set_res.ok, "scenes_set_active_scene returned not ok");
     }
 
-    // Clean up the saved scene file and directory if they exist
-    let _ = fs::remove_file(&full_path);
+    // Clean up the saved scene directory and its meta file if they exist
     if let Some(parent) = full_path.parent() {
-        let _ = fs::remove_dir(parent);
+        let _ = fs::remove_dir_all(parent);
+        let _ = fs::remove_file(parent.with_extension("meta"));
     }
 }


### PR DESCRIPTION
## Summary
- remove Unity-generated `.meta` files and directory using `remove_dir_all` in scene integration test cleanup

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --test scene_integration -- --nocapture` (Unity Editor not available, test skipped)


------
https://chatgpt.com/codex/tasks/task_e_68b685273c9c832990879e0a5b16a1e7