### PR TITLE
feat: add Unity component management

### DIFF
--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ComponentsHandler.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ComponentsHandler.cs
@@ -37,6 +37,7 @@ namespace Mcp.Unity.V1.Ipc
 
         public static Pb.ComponentResponse Handle(Pb.ComponentRequest req, Bridge.Editor.Ipc.FeatureGuard features)
         {
+            features.RequireFeature(Bridge.Editor.Ipc.FeatureFlag.ComponentsBasic);
             switch (req.PayloadCase)
             {
                 case Pb.ComponentRequest.PayloadOneofCase.Add:

--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/FeatureFlag.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/FeatureFlag.cs
@@ -11,6 +11,7 @@ namespace Bridge.Editor.Ipc
         BuildMin,
         EventsLog,
         OpsProgress,
+        ComponentsBasic,
         AssetsAdvanced,
         BuildFull,
         EventsFull,
@@ -25,6 +26,7 @@ namespace Bridge.Editor.Ipc
             { "build.min", FeatureFlag.BuildMin },
             { "events.log", FeatureFlag.EventsLog },
             { "ops.progress", FeatureFlag.OpsProgress },
+            { "components.basic", FeatureFlag.ComponentsBasic },
             { "assets.advanced", FeatureFlag.AssetsAdvanced },
             { "build.full", FeatureFlag.BuildFull },
             { "events.full", FeatureFlag.EventsFull },
@@ -53,6 +55,7 @@ namespace Bridge.Editor.Ipc
                 FeatureFlag.BuildMin,
                 FeatureFlag.EventsLog,
                 FeatureFlag.OpsProgress,
+                FeatureFlag.ComponentsBasic,
                 // Note: AssetsAdvanced, BuildFull, EventsFull not yet implemented
             };
         }

--- a/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ServerFeatureConfig.cs
+++ b/bridge/Packages/com.example.mcp-bridge/Editor/Ipc/ServerFeatureConfig.cs
@@ -39,6 +39,7 @@ namespace Bridge.Editor.Ipc
             features.Add(FeatureFlag.AssetsBasic);
             features.Add(FeatureFlag.EventsLog);
             features.Add(FeatureFlag.OpsProgress);
+            features.Add(FeatureFlag.ComponentsBasic);
             
             // Conditionally enabled features (using cached value)
             if (_isBuildSystemAvailable)

--- a/server/src/ipc/client.rs
+++ b/server/src/ipc/client.rs
@@ -376,6 +376,13 @@ impl IpcClient {
         component: String,
         timeout: Duration,
     ) -> Result<pb::AddComponentResponse, IpcError> {
+        // Check if components.basic feature is negotiated
+        if !self.has_feature(FeatureFlag::ComponentsBasic).await {
+            return Err(IpcError::UnsupportedFeature(
+                "components.basic feature not negotiated".into(),
+            ));
+        }
+
         let req = pb::IpcRequest {
             payload: Some(pb::ipc_request::Payload::Component(pb::ComponentRequest {
                 payload: Some(pb::component_request::Payload::Add(
@@ -406,6 +413,13 @@ impl IpcClient {
         game_object: String,
         timeout: Duration,
     ) -> Result<pb::GetComponentsResponse, IpcError> {
+        // Check if components.basic feature is negotiated
+        if !self.has_feature(FeatureFlag::ComponentsBasic).await {
+            return Err(IpcError::UnsupportedFeature(
+                "components.basic feature not negotiated".into(),
+            ));
+        }
+
         let req = pb::IpcRequest {
             payload: Some(pb::ipc_request::Payload::Component(pb::ComponentRequest {
                 payload: Some(pb::component_request::Payload::Get(
@@ -434,6 +448,13 @@ impl IpcClient {
         component: String,
         timeout: Duration,
     ) -> Result<pb::RemoveComponentResponse, IpcError> {
+        // Check if components.basic feature is negotiated
+        if !self.has_feature(FeatureFlag::ComponentsBasic).await {
+            return Err(IpcError::UnsupportedFeature(
+                "components.basic feature not negotiated".into(),
+            ));
+        }
+
         let req = pb::IpcRequest {
             payload: Some(pb::ipc_request::Payload::Component(pb::ComponentRequest {
                 payload: Some(pb::component_request::Payload::Remove(

--- a/server/src/ipc/features.rs
+++ b/server/src/ipc/features.rs
@@ -15,6 +15,9 @@ pub enum FeatureFlag {
     // Operations
     OpsProgress, // "ops.progress" - generic progress events for long-running operations
 
+    // Components
+    ComponentsBasic, // "components.basic" - add/get/remove components
+
     // Future extensions
     AssetsAdvanced, // "assets.advanced" - asset streaming, dependencies
     BuildFull,      // "build.full" - full build pipeline with addressables
@@ -31,6 +34,7 @@ impl FeatureFlag {
             "build.min" => Self::BuildMin,
             "events.log" => Self::EventsLog,
             "ops.progress" => Self::OpsProgress,
+            "components.basic" => Self::ComponentsBasic,
             "assets.advanced" => Self::AssetsAdvanced,
             "build.full" => Self::BuildFull,
             "events.full" => Self::EventsFull,
@@ -44,6 +48,7 @@ impl FeatureFlag {
             Self::BuildMin,
             Self::EventsLog,
             Self::OpsProgress,
+            Self::ComponentsBasic,
         ]
     }
 
@@ -60,6 +65,7 @@ impl fmt::Display for FeatureFlag {
             Self::BuildMin => "build.min",
             Self::EventsLog => "events.log",
             Self::OpsProgress => "ops.progress",
+            Self::ComponentsBasic => "components.basic",
             Self::AssetsAdvanced => "assets.advanced",
             Self::BuildFull => "build.full",
             Self::EventsFull => "events.full",
@@ -142,6 +148,10 @@ mod tests {
             FeatureFlag::from_string("ops.progress"),
             FeatureFlag::OpsProgress
         );
+        assert_eq!(
+            FeatureFlag::from_string("components.basic"),
+            FeatureFlag::ComponentsBasic
+        );
 
         match FeatureFlag::from_string("unknown.feature") {
             FeatureFlag::Unknown(s) => assert_eq!(s, "unknown.feature"),
@@ -155,6 +165,7 @@ mod tests {
         assert_eq!(FeatureFlag::BuildMin.to_string(), "build.min");
         assert_eq!(FeatureFlag::EventsLog.to_string(), "events.log");
         assert_eq!(FeatureFlag::OpsProgress.to_string(), "ops.progress");
+        assert_eq!(FeatureFlag::ComponentsBasic.to_string(), "components.basic");
     }
 
     #[test]

--- a/server/tests/ipc_integration.rs
+++ b/server/tests/ipc_integration.rs
@@ -527,6 +527,7 @@ async fn test_supported_by_client() -> anyhow::Result<()> {
     assert!(client_features.contains(&FeatureFlag::BuildMin));
     assert!(client_features.contains(&FeatureFlag::EventsLog));
     assert!(client_features.contains(&FeatureFlag::OpsProgress));
+    assert!(client_features.contains(&FeatureFlag::ComponentsBasic));
     assert!(!client_features.contains(&FeatureFlag::AssetsAdvanced));
 
     Ok(())


### PR DESCRIPTION
## Summary
- introduce `components.basic` feature flag and require it for component operations
- gate Rust client component APIs behind negotiated `components.basic`
- advertise `components.basic` in Unity bridge and server feature sets

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --test components_integration`


------
https://chatgpt.com/codex/tasks/task_e_68b68538f958832987c675c5e422350c